### PR TITLE
Make OrgToken more robust

### DIFF
--- a/pypco/auth_config.py
+++ b/pypco/auth_config.py
@@ -2,7 +2,6 @@
 
 import base64
 from enum import Enum, auto
-from typing import Optional
 
 from pypco.user_auth_helpers import get_cc_org_token
 from .exceptions import PCOCredentialsException

--- a/pypco/auth_config.py
+++ b/pypco/auth_config.py
@@ -77,7 +77,7 @@ class PCOAuthConfig:
             )
 
         if self.auth_type == PCOAuthType.ORGTOKEN:
-            return f"OrganizationToken {get_cc_org_token(self.cc_name)}"
+            return f"OrganizationToken {str(get_cc_org_token(self.cc_name))}"
 
         # Otherwise OAUTH using the Bearer scheme
         return "Bearer {}".format(self.token)

--- a/pypco/auth_config.py
+++ b/pypco/auth_config.py
@@ -4,6 +4,7 @@ import base64
 from enum import Enum, auto
 
 from .exceptions import PCOCredentialsException
+from pypco.user_auth_helpers import get_cc_org_token
 
 
 class PCOAuthType(Enum):  # pylint: disable=R0903
@@ -21,16 +22,16 @@ class PCOAuthConfig:
             application_id (str): The application ID for your application (PAT).
             secret (str): The secret for your application (PAT).
             token (str): The token for your application (OAUTH).
-            org_token (str): The OrganizationToken used for api.churchcenter.com
+            cc_name (str): The vanity name portion of the <vanity_name>.churchcenter.com url
             auth_type (PCOAuthType): The authentication type specified by this config object.
     """
 
-    def __init__(self, application_id: str = None, secret: str = None, token: str = None, org_token: str = None):
+    def __init__(self, application_id: str = None, secret: str = None, token: str = None, cc_name: str = None):
 
         self.application_id = application_id
         self.secret = secret
         self.token = token
-        self.org_token = org_token
+        self.cc_name = cc_name
 
     @property
     def auth_type(self) -> PCOAuthType:
@@ -43,11 +44,11 @@ class PCOAuthConfig:
             PCOAuthType: The authentication type for this config.
         """
 
-        if self.application_id and self.secret and not (self.token or self.org_token):  # pylint: disable=no-else-return
+        if self.application_id and self.secret and not (self.token or self.cc_name):  # pylint: disable=no-else-return
             return PCOAuthType.PAT
-        elif self.token and not (self.application_id or self.secret or self.org_token):
+        elif self.token and not (self.application_id or self.secret or self.cc_name):
             return PCOAuthType.OAUTH
-        elif self.org_token and not (self.application_id or self.secret or self.token):
+        elif self.cc_name and not (self.application_id or self.secret or self.token):
             return PCOAuthType.ORGTOKEN
         else:
             raise PCOCredentialsException(
@@ -76,7 +77,7 @@ class PCOAuthConfig:
             )
 
         if self.auth_type == PCOAuthType.ORGTOKEN:
-            return "OrganizationToken {}".format(self.org_token)
+            return "OrganizationToken {}".format(get_cc_org_token(self.cc_name)['data']['attributes']['token'])
 
         # Otherwise OAUTH using the Bearer scheme
         return "Bearer {}".format(self.token)

--- a/pypco/auth_config.py
+++ b/pypco/auth_config.py
@@ -2,9 +2,10 @@
 
 import base64
 from enum import Enum, auto
+from typing import Optional
 
-from .exceptions import PCOCredentialsException
 from pypco.user_auth_helpers import get_cc_org_token
+from .exceptions import PCOCredentialsException
 
 
 class PCOAuthType(Enum):  # pylint: disable=R0903
@@ -77,7 +78,7 @@ class PCOAuthConfig:
             )
 
         if self.auth_type == PCOAuthType.ORGTOKEN:
-            return f"OrganizationToken {str(get_cc_org_token(self.cc_name))}"
+            return f"OrganizationToken {get_cc_org_token(self.cc_name)}"
 
         # Otherwise OAUTH using the Bearer scheme
         return "Bearer {}".format(self.token)

--- a/pypco/auth_config.py
+++ b/pypco/auth_config.py
@@ -77,7 +77,7 @@ class PCOAuthConfig:
             )
 
         if self.auth_type == PCOAuthType.ORGTOKEN:
-            return "OrganizationToken {}".format(get_cc_org_token(self.cc_name)['data']['attributes']['token'])
+            return f"OrganizationToken {get_cc_org_token(self.cc_name)}"
 
         # Otherwise OAUTH using the Bearer scheme
         return "Bearer {}".format(self.token)

--- a/pypco/pco.py
+++ b/pypco/pco.py
@@ -38,7 +38,7 @@ class PCO:  #pylint: disable=too-many-instance-attributes
             application_id: str = None,
             secret: str = None,
             token: str = None,
-            org_token: str = None,
+            cc_name: str = None,
             api_base: str = 'https://api.planningcenteronline.com',
             timeout: int = 60,
             upload_url: str = 'https://upload.planningcenteronline.com/v2/files',
@@ -48,7 +48,7 @@ class PCO:  #pylint: disable=too-many-instance-attributes
 
         self._log = logging.getLogger(__name__)
 
-        self._auth_config = PCOAuthConfig(application_id, secret, token, org_token)
+        self._auth_config = PCOAuthConfig(application_id, secret, token, cc_name)
         self._auth_header = self._auth_config.auth_header
 
         self.api_base = api_base

--- a/pypco/user_auth_helpers.py
+++ b/pypco/user_auth_helpers.py
@@ -1,7 +1,7 @@
 """User-facing authentication helper functions for pypco."""
 
 import urllib
-from typing import List
+from typing import List, Optional
 from json import JSONDecodeError
 
 import requests
@@ -144,7 +144,7 @@ def get_oauth_refresh_token(client_id: str, client_secret: str, refresh_token: s
     ).json()
 
 
-def get_cc_org_token(cc_name: str) -> str:
+def get_cc_org_token(cc_name: Optional[str] = None) -> Optional[str]:
     """Get a non-authenticated Church Center OrganizationToken.
 
     Args:

--- a/pypco/user_auth_helpers.py
+++ b/pypco/user_auth_helpers.py
@@ -144,7 +144,7 @@ def get_oauth_refresh_token(client_id: str, client_secret: str, refresh_token: s
     ).json()
 
 
-def get_cc_org_token(cc_url: str) -> dict:
+def get_cc_org_token(cc_name: str) -> str:
     """Get a non-authenticated Church Center OrganizationToken.
 
     Args:
@@ -157,7 +157,7 @@ def get_cc_org_token(cc_url: str) -> dict:
     """
     try:
         response = requests.post(
-            f'https://{cc_url}.churchcenter.com/sessions/tokens',
+            f'https://{cc_name}.churchcenter.com/sessions/tokens',
             timeout=30
         )
 
@@ -176,6 +176,6 @@ def get_cc_org_token(cc_url: str) -> dict:
         ) from err
     try:
         response.json()
-        return response.json()
+        return response.json()['data']['attributes']['token']
     except JSONDecodeError as err:
         raise PCOUnexpectedRequestException("Invalid Church Center URL") from err

--- a/pypco/user_auth_helpers.py
+++ b/pypco/user_auth_helpers.py
@@ -144,7 +144,7 @@ def get_oauth_refresh_token(client_id: str, client_secret: str, refresh_token: s
     ).json()
 
 
-def get_cc_org_token(cc_name: Optional[str] = None) -> Optional[str]:
+def get_cc_org_token(cc_name: Optional[str] = None) -> Optional[str]: # pylint: disable=unsubscriptable-object
     """Get a non-authenticated Church Center OrganizationToken.
 
     Args:

--- a/pypco/user_auth_helpers.py
+++ b/pypco/user_auth_helpers.py
@@ -176,6 +176,6 @@ def get_cc_org_token(cc_name: str) -> str:
         ) from err
     try:
         response.json()
-        return response.json()['data']['attributes']['token']
+        return str(response.json()['data']['attributes']['token'])
     except JSONDecodeError as err:
         raise PCOUnexpectedRequestException("Invalid Church Center URL") from err

--- a/pypco/user_auth_helpers.py
+++ b/pypco/user_auth_helpers.py
@@ -148,7 +148,7 @@ def get_cc_org_token(cc_name: str) -> str:
     """Get a non-authenticated Church Center OrganizationToken.
 
     Args:
-        cc_url (str): The organization_name part of the organization_name.churchcenter.com url.
+        cc_name (str): The organization_name part of the organization_name.churchcenter.com url.
 
     Raises:
 

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -34,11 +34,11 @@ class TestPCOAuthConfig(BasePCOTestCase):
     def test_org_token(self):
         """Verify class functionality with ORGTOKEN."""
 
-        auth_config = PCOAuthConfig(org_token="abcd1234")
+        auth_config = PCOAuthConfig(cc_name="carlsbad")
 
         self.assertIsInstance(auth_config, PCOAuthConfig, "Class is not instance of PCOAuthConfig!")
 
-        self.assertIsNotNone(auth_config.org_token, "No token found on object!")
+        self.assertIsNotNone(auth_config.cc_name, "No token found on object!")
 
         self.assertEqual(auth_config.auth_type, PCOAuthType.ORGTOKEN, "Wrong authentication type!")
 
@@ -63,15 +63,15 @@ class TestPCOAuthConfig(BasePCOTestCase):
 
         # Test with org_token and auth_id
         with self.assertRaises(PCOCredentialsException):
-            PCOAuthConfig(application_id='bad_app_id', org_token='token').auth_type  # pylint: disable=W0106
+            PCOAuthConfig(application_id='bad_app_id', cc_name='carlsbad').auth_type  # pylint: disable=W0106
 
         # Test with org_token and secret
         with self.assertRaises(PCOCredentialsException):
-            PCOAuthConfig(secret='bad_secret', org_token='token').auth_type  # pylint: disable=W0106
+            PCOAuthConfig(secret='bad_secret', cc_name='carlsbad').auth_type  # pylint: disable=W0106
 
         # Test with org_token and token
         with self.assertRaises(PCOCredentialsException):
-            PCOAuthConfig(token='bad_token', org_token='token').auth_type  # pylint: disable=W0106
+            PCOAuthConfig(token='bad_token', cc_name='carlsbad').auth_type  # pylint: disable=W0106
 
         # Test with no args
         with self.assertRaises(PCOCredentialsException):
@@ -91,6 +91,6 @@ class TestPCOAuthConfig(BasePCOTestCase):
                          "Invalid OAUTH authentication header.")
 
         # ORGTOKEN
-        auth_config = PCOAuthConfig(org_token="abcd1234")
-        self.assertEqual(auth_config.auth_header, "OrganizationToken abcd1234",
+        auth_config = PCOAuthConfig(cc_name="carlsbad")
+        self.assertIn('OrganizationToken', auth_config.auth_header,
                          "Invalid ORGTOKEN authentication header.")

--- a/tests/test_user_auth_helpers.py
+++ b/tests/test_user_auth_helpers.py
@@ -371,17 +371,18 @@ class TestGetCcOrgToken(unittest.TestCase):
         """Verify successful refresh with valid token."""
 
         """Existing valid cc subdomain"""
-        self.assertIn(
-            'token',
-            pypco.get_cc_org_token(
-                'yourcbcfamily',
-            )['data']['attributes']
+        self.assertIs(
+            str,
+            type(pypco.get_cc_org_token(
+                'carlsbad',
+            )),
+            "No String Returned"
         )
 
     def test_invalid_org_token(self):
         with self.assertRaises(PCOUnexpectedRequestException):
             pypco.get_cc_org_token(
-                'yourbcfamily',
+                'carlsbadtypo',
             )
 
     @mock.patch('requests.post', side_effect=Timeout)


### PR DESCRIPTION
The OrganizationToken is short lived. On church center they get a new token for each request. This changes the behavior so that we also get a new token on each request for OrgToken Auth only.