### PR TITLE
fix: fixed teardown of PCO class where authentication failed

### DIFF
--- a/pypco/pco.py
+++ b/pypco/pco.py
@@ -536,8 +536,8 @@ class PCO:  # pylint: disable=too-many-instance-attributes
 
     def __del__(self):
         """Close the requests session when the PCO object goes out of scope."""
-
-        self.session.close()
+        if self.session is not None:
+            self.session.close()
 
     @staticmethod
     def template(

--- a/tests/test_pco.py
+++ b/tests/test_pco.py
@@ -11,7 +11,7 @@ from requests.exceptions import SSLError
 
 import pypco
 from pypco.exceptions import PCORequestTimeoutException, \
-    PCORequestException, PCOUnexpectedRequestException
+    PCORequestException, PCOUnexpectedRequestException, PCOCredentialsException
 from pypco.auth_config import PCOAuthConfig
 from tests import BasePCOTestCase, BasePCOVCRTestCase
 
@@ -774,6 +774,10 @@ class TestPCOInitialization(BasePCOTestCase):
 
     def test_pco_initialization(self):
         """Test initializing the PCO object with various combinations of arguments."""
+
+        # region no Args:
+        with self.assertRaises(PCOCredentialsException):
+            pypco.PCO()
 
         # region Minimal Args: PAT Auth
         pco = pypco.PCO(


### PR DESCRIPTION
When tearing down an PCO class, that was initialized without parameters, first an PCOCredentialsexception error occurs. When that is catched, an AttributeError occurs, because during teardown it tries to close the session which won't hasn't been defined yet.

```python
.....Exception ignored in: <function PCO.__del__ at 0x7fdb3dc83ee0>
Traceback (most recent call last):
  File "/home/fk/pypco/pypco/pco.py", line 539, in __del__
    if self.session is not None:
AttributeError: 'PCO' object has no attribute 'session'
``` 