### PR TITLE
Make iterate function work with Registrations API

### DIFF
--- a/pypco/__init__.py
+++ b/pypco/__init__.py
@@ -16,7 +16,7 @@ pypco supports both OAUTH and Personal Access Token (PAT) authentication.
 """
 
 # PyPCO Version
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 # Export the interface we present to clients
 

--- a/pypco/pco.py
+++ b/pypco/pco.py
@@ -469,7 +469,6 @@ class PCO:  # pylint: disable=too-many-instance-attributes
             with which they are associated. This makes it easier to process includes associated with
             specific objects since they are accessible directly from each returned object.
         """
-
         while True:  # pylint: disable=too-many-nested-blocks
 
             response = self.get(url, offset=offset, per_page=per_page, **params)
@@ -477,7 +476,10 @@ class PCO:  # pylint: disable=too-many-instance-attributes
             if response is None:
                 return
 
-            for cur in response['data']:
+            # Sometimes the returned data is a list of dicts and sometimes it's a dict
+            data_items = response['data'] if isinstance(response['data'], list) else [response['data']]
+            
+            for cur in data_items:
                 record = {
                     'data': cur,
                     'included': [],
@@ -512,7 +514,7 @@ class PCO:  # pylint: disable=too-many-instance-attributes
 
             offset += per_page
 
-            if 'next' not in response['links']:
+            if 'links' not in response or 'next' not in response['links']:
                 break
 
     def upload(self, file_path: str, **params) -> Optional[dict]:  # pylint: disable=unsubscriptable-object

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='pypco',
-    version='1.2.0',
+    version='1.2.1',
     description='A Python wrapper for the Planning Center Online API.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Before this PR, I couldn't run this simple script:
```
import pypco
pco = pypco.PCO("APP_ID", "APP_SECRET")

for registration in pco.iterate('/registrations/v2/signups/123456?include=next_signup_time,campuses,categories,signup_location,signup_times'):
  print(registration)
```

I would get an error when iterating over results from the Registrations API:
```
Traceback (most recent call last):
  File "/Users/micahstairs/planning-center/adhoc/list_registrations.py", line 9, in <module>
    for registration in pco.iterate('/registrations/v2/signups/123456'):
  File "/opt/homebrew/lib/python3.11/site-packages/pypco/pco.py", line 517, in iterate
    if 'next' not in response['links']:
```

NOTE: There's a chance that this error only happens when there is one result in the sign-up (which I had), I didn't test it with more than one. Either way, this iterate function should handle either case.